### PR TITLE
Make state change deactivatable for types

### DIFF
--- a/gradle/changelog/state_change_deactivatable.yaml
+++ b/gradle/changelog/state_change_deactivatable.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Make state change deactivatable for types ([#31](https://github.com/scm-manager/scm-issuetracker-plugin/pull/31))

--- a/src/main/java/sonia/scm/issuetracker/internal/ChangesetMapper.java
+++ b/src/main/java/sonia/scm/issuetracker/internal/ChangesetMapper.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class ChangesetMapper {
 
-  static final String TYPE = "changeset";
+  public static final String TYPE = "changeset";
 
   private final ScmConfiguration configuration;
 

--- a/src/main/java/sonia/scm/issuetracker/internal/review/PullRequestCommentMapper.java
+++ b/src/main/java/sonia/scm/issuetracker/internal/review/PullRequestCommentMapper.java
@@ -26,7 +26,6 @@ package sonia.scm.issuetracker.internal.review;
 
 import com.cloudogu.scm.review.comment.service.BasicComment;
 import com.cloudogu.scm.review.pullrequest.service.PullRequest;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import sonia.scm.config.ScmConfiguration;
@@ -45,8 +44,7 @@ import java.util.List;
 @Requires("scm-review-plugin")
 public class PullRequestCommentMapper {
 
-  @VisibleForTesting
-  static final String TYPE = "comment";
+  public static final String TYPE = "comment";
 
   private final ScmConfiguration configuration;
   private final PersonMapper personMapper;

--- a/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
@@ -31,7 +31,6 @@ import sonia.scm.issuetracker.IssueMatcher;
 import sonia.scm.issuetracker.api.IssueReferencingObject;
 import sonia.scm.issuetracker.api.IssueTracker;
 import sonia.scm.issuetracker.api.Resubmitter;
-import sonia.scm.issuetracker.internal.ChangesetMapper;
 
 import java.io.IOException;
 import java.util.*;
@@ -162,10 +161,10 @@ class DefaultIssueTracker implements IssueTracker {
     }
     try {
       String comment = stateChangeCommentRenderer.render(object, keyWord);
-      if (ChangesetMapper.TYPE.equals(object.getType()) && stateChanger.isStateChangeForCommitsDisabled()) {
-        LOG.trace("ignoring state change for {} because state change for commits is disabled", object.getRepository());
-      } else {
+      if (stateChanger.isStateChangeActivatedFor(object.getType())) {
         stateChanger.changeState(issueKey, keyWord);
+      } else {
+        LOG.trace("ignoring state change for type {} in repository {}, because state change for this type is disabled", object.getType(), object.getRepository());
       }
       commentator.comment(issueKey, comment);
       store.mark(issueKey, object, keyWord);

--- a/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
@@ -151,7 +151,7 @@ class DefaultIssueTracker implements IssueTracker {
       if (stateChanger.isStateChangeActivatedFor(object.getType())) {
         changeState(object, issueKey, stateChange.get());
       } else {
-        LOG.trace("ignoring state change for type {} in repository {}, because state change for this type is disabled", object.getType(), object.getRepository());
+        LOG.trace("ignoring state change for type '{}' in repository {}, because state change for this type is disabled", object.getType(), object.getRepository());
         comment(object, issueKey);
       }
     } else {

--- a/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/DefaultIssueTracker.java
@@ -31,6 +31,7 @@ import sonia.scm.issuetracker.IssueMatcher;
 import sonia.scm.issuetracker.api.IssueReferencingObject;
 import sonia.scm.issuetracker.api.IssueTracker;
 import sonia.scm.issuetracker.api.Resubmitter;
+import sonia.scm.issuetracker.internal.ChangesetMapper;
 
 import java.io.IOException;
 import java.util.*;
@@ -161,7 +162,11 @@ class DefaultIssueTracker implements IssueTracker {
     }
     try {
       String comment = stateChangeCommentRenderer.render(object, keyWord);
-      stateChanger.changeState(issueKey, keyWord);
+      if (ChangesetMapper.TYPE.equals(object.getType()) && stateChanger.isStateChangeForCommitsDisabled()) {
+        LOG.trace("ignoring state change for {} because state change for commits is disabled", object.getRepository());
+      } else {
+        stateChanger.changeState(issueKey, keyWord);
+      }
       commentator.comment(issueKey, comment);
       store.mark(issueKey, object, keyWord);
     } catch (IOException ex) {

--- a/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
@@ -54,4 +54,12 @@ public interface StateChanger {
    */
   Iterable<String> getKeyWords(String issueKey) throws IOException;
 
+  /**
+   * If this returns <code>true</code>, state changes will not be performed for commits. The default implementation
+   * returns <code>false</code>.
+   * @return <code>false</code> by default.
+   */
+  default boolean isStateChangeForCommitsDisabled() {
+    return false;
+  }
 }

--- a/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
@@ -24,6 +24,9 @@
 
 package sonia.scm.issuetracker.spi;
 
+import sonia.scm.issuetracker.internal.ChangesetMapper;
+import sonia.scm.issuetracker.internal.review.PullRequestCommentMapper;
+
 import java.io.IOException;
 
 /**
@@ -55,11 +58,47 @@ public interface StateChanger {
   Iterable<String> getKeyWords(String issueKey) throws IOException;
 
   /**
-   * If this returns <code>true</code>, state changes will not be performed for commits. The default implementation
-   * returns <code>false</code>.
-   * @return <code>false</code> by default.
+   * This will be called before a state change is performed for the given type. The type might be
+   * <ul>
+   *   <li>{@link ChangesetMapper#TYPE} (<code>{@value ChangesetMapper#TYPE}</code>),</li>
+   *   <li>{@link PullRequestCommentMapper#TYPE} (<code>{@value PullRequestCommentMapper#TYPE}</code>), or</li>
+   *   <li>another value if this is used by further plugins.</li>
+   * </ul>
+   * @param type The type of the event that triggers the state change.
+   * @return <code>true</code>, if the state change should be performed, <code>false</code> otherwise.
    */
-  default boolean isStateChangeForCommitsDisabled() {
-    return false;
+  default boolean isStateChangeActivatedFor(String type) {
+    switch (type) {
+      case ChangesetMapper.TYPE:
+        return isStateChangeActivatedForCommits();
+      case PullRequestCommentMapper.TYPE:
+        return isStateChangeActivatedForPullRequests();
+      default:
+        return true;
+    }
+  }
+
+  /**
+   * This is used by {@link #isStateChangeActivatedFor(String)} and therefore will not be called, if the
+   * default implementation of {@link #isStateChangeActivatedFor(String)} is not used by the implementation of this
+   * interface.
+   * If this returns <code>false</code>, state changes will be performed for commits. The default implementation
+   * returns <code>true</code>.
+   * @return <code>true</code> by default.
+   */
+  default boolean isStateChangeActivatedForCommits() {
+    return true;
+  }
+
+  /**
+   * This is used by {@link #isStateChangeActivatedFor(String)} and therefore will not be called, if the
+   * default implementation of {@link #isStateChangeActivatedFor(String)} is not used by the implementation of this
+   * interface.
+   * If this returns <code>false</code>, state changes will be performed for pull requests. The default implementation
+   * returns <code>true</code>.
+   * @return <code>true</code> by default.
+   */
+  default boolean isStateChangeActivatedForPullRequests() {
+    return true;
   }
 }

--- a/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
+++ b/src/main/java/sonia/scm/issuetracker/spi/StateChanger.java
@@ -64,6 +64,9 @@ public interface StateChanger {
    *   <li>{@link PullRequestCommentMapper#TYPE} (<code>{@value PullRequestCommentMapper#TYPE}</code>), or</li>
    *   <li>another value if this is used by further plugins.</li>
    * </ul>
+   * The default implementation delegates to {@link #isStateChangeActivatedForCommits()} for commits and
+   * {@link #isStateChangeActivatedForPullRequests()} for pull requests and returns <code>true</code> for
+   * all other types.
    * @param type The type of the event that triggers the state change.
    * @return <code>true</code>, if the state change should be performed, <code>false</code> otherwise.
    */

--- a/src/test/java/sonia/scm/issuetracker/IssueReferencingObjects.java
+++ b/src/test/java/sonia/scm/issuetracker/IssueReferencingObjects.java
@@ -58,13 +58,17 @@ public class IssueReferencingObjects {
   }
 
   public static IssueReferencingObject content(boolean triggeringStateChange, String... values) {
+    return content("unit-test", triggeringStateChange, values);
+  }
+
+  public static IssueReferencingObject content(String type, boolean triggeringStateChange, String... values) {
     List<Content> content = new ArrayList<>();
     for (int i = 0; i < values.length; i++) {
       content.add(new Content("c" + i, values[i]));
     }
     return new IssueReferencingObject(
       RepositoryTestData.createHeartOfGold(),
-      "unit-test",
+      type,
       "42",
       Person.toPerson("Trillian"),
       Instant.now(),

--- a/src/test/java/sonia/scm/issuetracker/IssueReferencingObjects.java
+++ b/src/test/java/sonia/scm/issuetracker/IssueReferencingObjects.java
@@ -58,17 +58,13 @@ public class IssueReferencingObjects {
   }
 
   public static IssueReferencingObject content(boolean triggeringStateChange, String... values) {
-    return content("unit-test", triggeringStateChange, values);
-  }
-
-  public static IssueReferencingObject content(String type, boolean triggeringStateChange, String... values) {
     List<Content> content = new ArrayList<>();
     for (int i = 0; i < values.length; i++) {
       content.add(new Content("c" + i, values[i]));
     }
     return new IssueReferencingObject(
       RepositoryTestData.createHeartOfGold(),
-      type,
+      "unit-test",
       "42",
       Person.toPerson("Trillian"),
       Instant.now(),

--- a/src/test/java/sonia/scm/issuetracker/spi/DefaultIssueTrackerTest.java
+++ b/src/test/java/sonia/scm/issuetracker/spi/DefaultIssueTrackerTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -256,11 +257,12 @@ class DefaultIssueTrackerTest {
     void shouldNotChangeStateForCommitIfDisabled() throws IOException {
       IssueReferencingObject ref = content("Fixes #42");
       when(stateChanger.getKeyWords("#42")).thenReturn(Collections.singleton("fixes"));
-      when(stateChangeCommentRenderer.render(ref, "fixes")).thenReturn("Incredible");
+      when(referenceCommentRenderer.render(ref)).thenReturn("Incredible");
 
       tracker.process(ref);
       verify(stateChanger, never()).changeState("#42", "fixes");
       verify(commentator).comment("#42", "Incredible");
+      verify(stateChangeCommentRenderer, never()).render(any(), any());
     }
 
     @Test

--- a/src/test/java/sonia/scm/issuetracker/spi/DefaultIssueTrackerTest.java
+++ b/src/test/java/sonia/scm/issuetracker/spi/DefaultIssueTrackerTest.java
@@ -35,6 +35,7 @@ import sonia.scm.issuetracker.ExampleIssueLinkFactory;
 import sonia.scm.issuetracker.ExampleIssueMatcher;
 import sonia.scm.issuetracker.api.IssueReferencingObject;
 import sonia.scm.issuetracker.api.IssueTracker;
+import sonia.scm.issuetracker.internal.ChangesetMapper;
 import sonia.scm.issuetracker.internal.resubmit.ResubmitQueue;
 import sonia.scm.repository.RepositoryTestData;
 import sonia.scm.store.InMemoryDataStoreFactory;
@@ -203,6 +204,18 @@ class DefaultIssueTrackerTest {
 
       tracker.process(ref);
       verify(stateChanger).changeState("#42", "fixes");
+      verify(commentator).comment("#42", "Incredible");
+    }
+
+    @Test
+    void shouldNotChangeStateForCommitIfDisabled() throws IOException {
+      IssueReferencingObject ref = content(ChangesetMapper.TYPE, true, "Fixes #42");
+      when(stateChanger.isStateChangeForCommitsDisabled()).thenReturn(true);
+      when(stateChanger.getKeyWords("#42")).thenReturn(Collections.singleton("fixes"));
+      when(stateChangeCommentRenderer.render(ref, "fixes")).thenReturn("Incredible");
+
+      tracker.process(ref);
+      verify(stateChanger, never()).changeState("#42", "fixes");
       verify(commentator).comment("#42", "Incredible");
     }
 


### PR DESCRIPTION
## Proposed changes

Adds the possibility for concrete plugins to disable the state transition for single types like "commits" or "pull requests".

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
