### PR TITLE
fix problem with similar issue ids

### DIFF
--- a/src/main/js/IssueLinkMarkdownPlugin.test.ts
+++ b/src/main/js/IssueLinkMarkdownPlugin.test.ts
@@ -162,6 +162,86 @@ describe("IssueLinkMarkdownPlugin tests", () => {
     ];
     test(issues, content, expected);
   });
+  it("should replace issue ids with links #4.1", () => {
+    const issues = [
+      {
+        name: "#2",
+        href: "https://hitchhiker.com/issues/2"
+      },
+      {
+        name: "#21",
+        href: "https://hitchhiker.com/issues/21"
+      }
+    ] as Issue[];
+    const content = "Lets try #2 and #21 together";
+    const expected = [
+      { type: "text", value: "Lets try " },
+      {
+        children: [{ type: "text", value: "#2" }],
+        title: "Issue #2",
+        type: "link",
+        url: "https://hitchhiker.com/issues/2"
+      },
+      { type: "text", value: " and " },
+      {
+        children: [{ type: "text", value: "#21" }],
+        title: "Issue #21",
+        type: "link",
+        url: "https://hitchhiker.com/issues/21"
+      },
+      { type: "text", value: " together" }
+    ];
+    test(issues, content, expected);
+  });
+  it("should replace issue ids with links #4.2", () => {
+    const issues = [
+      {
+        name: "#2",
+        href: "https://hitchhiker.com/issues/2"
+      },
+      {
+        name: "#234",
+        href: "https://hitchhiker.com/issues/234"
+      },
+      {
+        name: "#21",
+        href: "https://hitchhiker.com/issues/21"
+      }
+    ] as Issue[];
+    const content = "What about #2, #234 and (#21) OR [#234]";
+    const expected = [
+      { type: "text", value: "What about " },
+      {
+        children: [{ type: "text", value: "#2" }],
+        title: "Issue #2",
+        type: "link",
+        url: "https://hitchhiker.com/issues/2"
+      },
+      { type: "text", value: ", " },
+      {
+        children: [{ type: "text", value: "#234" }],
+        title: "Issue #234",
+        type: "link",
+        url: "https://hitchhiker.com/issues/234"
+      },
+      { type: "text", value: " and (" },
+      {
+        children: [{ type: "text", value: "#21" }],
+        title: "Issue #21",
+        type: "link",
+        url: "https://hitchhiker.com/issues/21"
+      },
+      { type: "text", value: ") OR [" },
+      {
+        children: [{ type: "text", value: "#234" }],
+        title: "Issue #234",
+        type: "link",
+        url: "https://hitchhiker.com/issues/234"
+      },
+      { type: "text", value: "]" }
+    ];
+    test(issues, content, expected);
+  });
   it("should do nothing if there are no issue links", () => {
     const halObject = {
       _links: {}

--- a/src/main/js/IssueLinkMarkdownPlugin.ts
+++ b/src/main/js/IssueLinkMarkdownPlugin.ts
@@ -34,11 +34,17 @@ type FoundIndex = {
 };
 
 function findIndicesOfIssues(issues: Issue[], nodeText: string) {
+  issues.sort((a, b) => b.name.length - a.name.length);
   const foundIndices: FoundIndex[] = [];
   for (const { href, name } of issues) {
-    let idx = -1;
-    while ((idx = nodeText.indexOf(name, idx + 1)) !== -1) {
-      foundIndices.push({ idx, name, href });
+    let idx = nodeText.indexOf(name, 0);
+
+    while (idx !== -1) {
+      const safeIdx = idx;
+      if (!foundIndices.some(it => it.idx === safeIdx)) {
+        foundIndices.push({ idx, name, href });
+      }
+      idx = nodeText.indexOf(name, idx + 1);
     }
   }
   foundIndices.sort((a, b) => a.idx - b.idx);


### PR DESCRIPTION
## Proposed changes

If there are multiple issue ids where one contains the other (e.g. `#21` and `#2`) and a given text contains both, the replacement algorithm did not deal with it well. This behaviour is fixed by processing the issue ids by length (longest first) and skipping replacements where a previous id already matched.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [ ] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
